### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,15 +69,16 @@ class DataDogEvents {
             }).then(resp => {
                 resolve(resp.data);
             }).catch(err => {
-                let status = err.response.status;
+                if(err.response) {
+                    let status = err.response.status;
                 
-                if(status === 403) {
-                    err.message = 'Invalid API Key provided';
-                } else {
-                    let resp = err.response.data;
-                    if(resp.errors) err.message = resp.errors.join(', ');
+                    if(status === 403) {
+                        err.message = 'Invalid API Key provided';
+                    } else {
+                        let resp = err.response.data;
+                        if(resp.errors) err.message = resp.errors.join(', ');
+                    }
                 }
-                
                 reject(err);
             });
         });


### PR DESCRIPTION
fixed err handling to not assume that there is always a response object in the axios err handler. As per axios documentation of error handling, the axios library does not return in all cases the response property. This causes the node-datadog-events to crash. 